### PR TITLE
ci: enable Nix store caching for devbox and validate pipeline daily in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: Testing with devbox
 
-on: push
+on:
+  push: # Trigger on any push to any branch
+  schedule:
+    - cron: '45 23 * * *' # Run daily at 23:45 UTC
 
 jobs:
   test:
@@ -10,6 +13,8 @@ jobs:
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.11.0
+        with:
+          enable-cache: 'true' # Cache Nix store
 
       - name: Check Devbox Java (JDK) version
         run: devbox info jdk22


### PR DESCRIPTION
This commit updates the GitHub Actions workflow to:
- Enable caching for the Nix store when using devbox by setting `enable-cache: 'true'` on the devbox-install-action.
- Ensure regular validation of the pipeline and Maven tests by adding a daily scheduled run.

These changes minimize redundant downloads, reduce build times, and ensure the workflow is tested daily.
