### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Testing with devbox
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/eth-library/devbox-spring-demo/security/code-scanning/1](https://github.com/eth-library/devbox-spring-demo/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow at the proper scope. As none of the steps require write access to repository resources, the minimal safe permission set is `contents: read`. This can be done at either the root level (to apply to all jobs) or at the job level (to scope to only the job). The simplest and most maintainable is to add the block at the root of the YAML file, just below the workflow name or after the `on:` trigger. This change ensures that all actions in the workflow run with minimal permissions and do not inherit default, potentially overly permissive, GitHub token access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
